### PR TITLE
NPM test to run test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "test": "grunt test --force"
+    "test": "grunt --force"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",


### PR DESCRIPTION
There isn't. currently a Grunt task  called "test" this change allows the test runner to be used by NPM (specified by package.json) 

Running npm test will run the test runner for the project.
