### PR TITLE
Adding options for logging errors to a file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,7 +27,18 @@ module.exports = function(grunt) {
       all: {
         options: {
           'tag-pair': true,
-          'htmlhintrc': 'test/.htmlhintrc'
+          'htmlhintrc': 'test/.htmlhintrc',
+          'force': true
+        },
+        src: 'test/fixtures/*.html'
+      },
+      file: {
+        options: {
+          'tag-pair': true,
+          'htmlhintrc': 'test/.htmlhintrc',
+          'reporter': 'reporters/file.js',
+          'reporterOutput': 'tmp/htmlhint.txt',
+          'force': true
         },
         src: 'test/fixtures/*.html'
       }

--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ Default value: `false`
 
 Report HTMLHint errors but dont fail the task
 
+#### options.reporter
+Type: `string`
+Default value: '/reporters/console.js'
+Available values: '/reporters/console.js', '/reporters/file.js', 'path/to/your/custom/reporter.js'
+
+Using the default value will print errors to the console.
+
+The `reporters/file.js` option will log errors to a file.
+
+#### options.reporterOutput
+Type: `string`
+Default value: undefined
+
+The path path to the log file you would like errors to be logged to.
+
+This is required if you are using the `/reporters/file.js` option.
+
 ### Usage Examples
 
 #### Direct options
@@ -78,6 +95,20 @@ htmlhint: {
     src: ['path/to/**/*.html']
   },
   html2: {
+    src: ['path/to/**/*.html']
+  }
+}
+```
+
+#### Using a Custom Reporter
+
+```js
+htmlhint: {
+  options: {
+    'reporter': 'reporters/file.js',
+    'reporterOutput': 'tmp/htmlhint.txt',
+  },
+  html1: {
     src: ['path/to/**/*.html']
   }
 }

--- a/reporters/console.js
+++ b/reporters/console.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var grunt = require('grunt');
+
+module.exports = {
+  reporter: function(message) {
+    grunt.log.writeln( "[".red + ( "L" + message.line ).yellow + ":".red + ( "C" + message.col ).yellow + "]".red + ' ' + message.message.yellow );
+    var evidence = message.evidence,
+      col = message.col;
+    if (col === 0) {
+      evidence = '?'.inverse.red + evidence;
+    } else if (col > evidence.length) {
+      evidence = evidence + ' '.inverse.red;
+    } else {
+      evidence = evidence.slice(0, col - 1) + evidence[col - 1].inverse.red + evidence.slice(col);
+    }
+    grunt.log.writeln(evidence);
+  }
+};

--- a/reporters/file.js
+++ b/reporters/file.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var appendFileSync = require('fs').appendFileSync,
+    grunt          = require('grunt');
+
+module.exports = {
+  reporter: function(message, reporterOutput) {
+
+    var err = "[" + ( "L" + message.line ) + ":" + ( "C" + message.col ) + "]" + ' ' + message.message,
+        evidence = message.evidence;
+
+    appendFileSync(reporterOutput, '\n\t' + err + '\n\t' + evidence + '\n');
+
+  }
+};

--- a/tasks/htmlhint.js
+++ b/tasks/htmlhint.js
@@ -14,8 +14,9 @@ module.exports = function(grunt) {
 
     var HTMLHint  = require("htmlhint").HTMLHint;
     var options = this.options({
-        force: false
-      }), 
+        force: false,
+        reporter: 'reporters/console.js'
+      }),
       arrFilesSrc = this.filesSrc,
       verbose = grunt.verbose;
 
@@ -39,22 +40,17 @@ module.exports = function(grunt) {
         if (messages.length > 0) {
           verbose.or.write( msg );
           grunt.log.error();
+          if (options.reporterOutput) {
+            var appendFileSync = require('fs').appendFileSync;
+            appendFileSync(options.reporterOutput, '[file] ' + filepath + '\n');
+          }
         } else {
           verbose.ok();
         }
         messages.forEach(function( message ) {
-          grunt.log.writeln( "[".red + ( "L" + message.line ).yellow + ":".red + ( "C" + message.col ).yellow + "]".red + ' ' + message.message.yellow );
-          var evidence = message.evidence,
-            col = message.col;
-          if (col === 0) {
-            evidence = '?'.inverse.red + evidence;
-          } else if (col > evidence.length) {
-            evidence = evidence + ' '.inverse.red;
-          } else {
-            evidence = evidence.slice(0, col - 1) + evidence[col - 1].inverse.red + evidence.slice(col);
-          }
-          grunt.log.writeln(evidence);
-          hintCount ++;
+          var output = require(options.reporter);
+          output.reporter(message, options.reporterOutput);
+          hintCount++;
         });
       }
       else{


### PR DESCRIPTION
Hey, I've made some updates to this to add options externalize the reporters like JSHint does. I've also included reporters/file.js which will log the errors to a file rather than the console. This should address #3.
