### PR TITLE
resolve npm audit warnings & allow Travis build success w/"-f" (force) option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,6 @@ node_js:
 install:
   - npm install -g codecov
   - npm install
-script:
-  - 'grunt'
-install:
-  - npm install -g codecov
-  - npm install
 after_success:
   - npm run codecov
 branches:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "test": "grunt --force"
+    "test": "grunt -f"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "test": "grunt --force"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt": "1.0.1",
+    "grunt-contrib-jshint": "^2.0.0",
+    "grunt": "1.0.3",
     "grunt-cli": "1.2.0"
   },
   "peerDependencies": {
@@ -35,6 +35,6 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "htmlhint": "~0.9.13"
+    "htmlhint": "^0.10.1"
   }
 }


### PR DESCRIPTION
**Fixes**: #32 #33 

🚨 Please review the [guidelines for contributing](./CONTRIBUTING.md) and our [code of conduct](./CODE_OF_CONDUCT.md) to this repository. 🚨
**Please complete these steps and check these boxes (by putting an x inside the brackets) before filing your PR:**

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:
Resolves npm audit warnings and allows Travis-CI builds to succeed.

Minimal changes, all within `package.json`.

#### Proposed changes:

##### - use `grunt -f` instead of `grunt --force` so Travis builds work
````diff
   "scripts": {
-    "test": "grunt --force"
+    "test": "grunt -f"
   },
````

##### - update dependencies so there are no npm audit warnings
````diff
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt": "1.0.1",
+    "grunt-contrib-jshint": "^2.0.0",
+    "grunt": "1.0.3",
     "grunt-cli": "1.2.0"
   },
````
````diff
   "dependencies": {
-    "htmlhint": "~0.9.13"
+    "htmlhint": "^0.10.1"
   }
````

-

👍 Thank you!